### PR TITLE
Changes for process-1.1 and remove -XDatatypeContext

### DIFF
--- a/HSH.cabal
+++ b/HSH.cabal
@@ -23,43 +23,26 @@ flag buildtests
   description: Build the executable to run unit tests
   default: False
 
-flag newerprocess
-  description: Build using the process-1.1 as opposed to 1.0 API.
-  default: False
-
-
 library
   Exposed-Modules: HSH, HSH.Command, HSH.ShellEquivs, HSH.Channel
   Extensions: ExistentialQuantification, OverlappingInstances,
     UndecidableInstances, FlexibleContexts, CPP
-  Build-Depends: base >= 4 && < 5, mtl, regex-compat, MissingH>=1.0.0,
+  Build-Depends: base >= 4 && < 5, mtl, process, regex-compat, MissingH>=1.0.0,
     hslogger, filepath, regex-base, regex-posix, directory,
     bytestring
   if !os(windows)
     Build-Depends: unix
-  if flag(newerprocess)
-    Build-Depends: process >= 1.1.0.0
-  else 
-    Build-Depends: process < 1.1.0.0
   GHC-Options: -O2 -threaded -Wall
-
-  if flag(newerprocess)
-    GHC-options: -DPROCESS_LIB_1_1
-
 
 Executable runtests
   if flag(buildtests)
     Buildable: True
-    Build-Depends: base >= 4 && < 5, mtl, regex-compat,
+    Build-Depends: base >= 4 && < 5, mtl, process, regex-compat,
       MissingH>=1.0.0,
       hslogger, filepath, regex-base, regex-posix, directory,
       bytestring, HUnit, testpack
     if !os(windows)
       Build-Depends: unix
-    if flag(newerprocess)
-      Build-Depends: process >= 1.1.0.0
-    else 
-      Build-Depends: process < 1.1.0.0
   else
     Buildable: False
   Main-Is: runtests.hs
@@ -67,6 +50,3 @@ Executable runtests
   Extensions: ExistentialQuantification, OverlappingInstances,
     UndecidableInstances, FlexibleContexts, CPP
   GHC-Options: -O2 -threaded
-
-  if flag(newerprocess)
-    GHC-options: -DPROCESS_LIB_1_1

--- a/HSH/Command.hs
+++ b/HSH/Command.hs
@@ -293,7 +293,7 @@ genericCommand c environ (ChanHandle ih) =
                             std_out = CreatePipe,
                             std_err = Inherit,
                             close_fds = True
-#ifdef PROCESS_LIB_1_1
+#if MIN_VERSION_process(1,1,0)
 -- Or use GHC version as a proxy:  __GLASGOW_HASKELL__ >= 720
 			    -- Added field in process 1.1.0.0:
 			    , create_group = False
@@ -310,7 +310,7 @@ genericCommand cspec environ ichan =
                             std_out = CreatePipe,
                             std_err = Inherit,
                             close_fds = True
-#ifdef PROCESS_LIB_1_1
+#if MIN_VERSION_process(1,1,0)
 			    -- Added field in process 1.1.0.0:
 			    , create_group = False
 #endif


### PR DESCRIPTION
These patches handle API changes in process-1.1 and also remove usage of deprecated -XDatatypeContext for PipeCommand and EnvironCommand.
