### PR TITLE
Fix clashing imports

### DIFF
--- a/HSH/ShellEquivs.hs
+++ b/HSH/ShellEquivs.hs
@@ -86,7 +86,7 @@ import Data.Char (toLower, toUpper)
 import Text.Regex (matchRegex, mkRegex)
 import Text.Printf (printf)
 import Control.Monad (foldM)
-import System.Directory hiding (createDirectory)
+import System.Directory hiding (createDirectory, isSymbolicLink)
 import qualified Control.Exception as E 
 -- import System.FilePath (splitPath)
 


### PR DESCRIPTION
I wasn't able to build in GHC 8 due to System.Directory's introduction of "isSymbolicLink" which conflicts with another import.