### PR TITLE
Update for fields added in process 1.3.0 through 1.5.0

### DIFF
--- a/HSH/Command.hs
+++ b/HSH/Command.hs
@@ -301,6 +301,18 @@ genericCommand c environ (ChanHandle ih) =
 #if MIN_VERSION_process(1,2,0)
 			    , delegate_ctlc = False
 #endif
+#if MIN_VERSION_process(1,3,0)
+          , detach_console = False
+          , create_new_console = False
+          , new_session = False
+#endif
+#if MIN_VERSION_process(1,4,0)
+          , child_group = Nothing
+          , child_user = Nothing
+#endif
+#if MIN_VERSION_process(1,5,0)
+          , use_process_jobs = False
+#endif
 			   }
     in do (_, oh', _, ph) <- createProcess cp
           let oh = fromJust oh'
@@ -319,6 +331,18 @@ genericCommand cspec environ ichan =
 #endif
 #if MIN_VERSION_process(1,2,0)
 			    , delegate_ctlc = False
+#endif
+#if MIN_VERSION_process(1,3,0)
+          , detach_console = False
+          , create_new_console = False
+          , new_session = False
+#endif
+#if MIN_VERSION_process(1,4,0)
+          , child_group = Nothing
+          , child_user = Nothing
+#endif
+#if MIN_VERSION_process(1,5,0)
+          , use_process_jobs = False
 #endif
 			   }
     in do (ih', oh', _, ph) <- createProcess cp


### PR DESCRIPTION
FIx for runtime crashes caused by undefined fields in CreateProcess records

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jgoerzen/hsh/18)
<!-- Reviewable:end -->
